### PR TITLE
Uc

### DIFF
--- a/static/js/uc.js
+++ b/static/js/uc.js
@@ -2609,7 +2609,6 @@ function initBulkStaffing() {
   const supportDecreaseBtn = document.getElementById('support_decrease');
   const supportIncreaseBtn = document.getElementById('support_increase');
   const filterSelect = document.getElementById('bulk_filter_select');
-  const filterTypeRadios = document.querySelectorAll('input[name="bulk_filter_type"]');
   const previewBtn = document.getElementById('preview_bulk');
   const applyBtn = document.getElementById('apply_bulk');
   const resetBtn = document.getElementById('reset_bulk');
@@ -2628,16 +2627,8 @@ function initBulkStaffing() {
   supportDecreaseBtn?.addEventListener('click', () => updateCounter(supportCountInput, -1));
   supportIncreaseBtn?.addEventListener('click', () => updateCounter(supportCountInput, 1));
 
-  // Filter type change
-  filterTypeRadios.forEach(radio => {
-    radio.addEventListener('change', () => {
-      updateFilterOptions();
-    });
-  });
-
-  // Update filter options based on selected type
+  // Update filter options (only modules now)
   async function updateFilterOptions() {
-    const selectedType = document.querySelector('input[name="bulk_filter_type"]:checked')?.value;
     const select = filterSelect;
     
     if (!select) return;
@@ -2645,65 +2636,16 @@ function initBulkStaffing() {
     // Clear existing options
     select.innerHTML = '<option value="">Choose an option...</option>';
 
-    if (selectedType === 'activity') {
-      // Get unique session types from created sessions
-      const sessionTypes = await getSessionTypes();
-      sessionTypes.forEach(type => {
-        const option = document.createElement('option');
-        option.value = type.value;
-        option.textContent = type.label;
-        select.appendChild(option);
-      });
-    } else if (selectedType === 'session_name') {
-      // Get unique session names
-      const sessionNames = await getSessionNames();
-      sessionNames.forEach(name => {
-        const option = document.createElement('option');
-        option.value = name.value;
-        option.textContent = name.label;
-        select.appendChild(option);
-      });
-    } else if (selectedType === 'module') {
-      // Get unique modules
-      const modules = await getModules();
-      modules.forEach(module => {
-        const option = document.createElement('option');
-        option.value = module.value;
-        option.textContent = module.label;
-        select.appendChild(option);
-      });
-    }
+    // Get unique modules
+    const modules = await getModules();
+    modules.forEach(module => {
+      const option = document.createElement('option');
+      option.value = module.value;
+      option.textContent = module.label;
+      select.appendChild(option);
+    });
   }
 
-  // Get session types from created sessions
-  async function getSessionTypes() {
-    const unitId = document.getElementById('unit_id')?.value;
-    if (!unitId) return [];
-    
-    try {
-      const response = await fetch(`/unitcoordinator/units/${unitId}/bulk-staffing/filters?type=activity`);
-      const data = await response.json();
-      return data.ok ? data.options : [];
-    } catch (e) {
-      console.error('Failed to fetch session types:', e);
-      return [];
-    }
-  }
-
-  // Get session names from created sessions
-  async function getSessionNames() {
-    const unitId = document.getElementById('unit_id')?.value;
-    if (!unitId) return [];
-    
-    try {
-      const response = await fetch(`/unitcoordinator/units/${unitId}/bulk-staffing/filters?type=session_name`);
-      const data = await response.json();
-      return data.ok ? data.options : [];
-    } catch (e) {
-      console.error('Failed to fetch session names:', e);
-      return [];
-    }
-  }
 
   // Get modules from the current unit
   async function getModules() {
@@ -2762,10 +2704,8 @@ function initBulkStaffing() {
     const unitId = document.getElementById('unit_id')?.value;
     if (!unitId) return [];
     
-    const selectedType = document.querySelector('input[name="bulk_filter_type"]:checked')?.value;
-    
     try {
-      const response = await fetch(`/unitcoordinator/units/${unitId}/bulk-staffing/sessions?type=${selectedType}&value=${encodeURIComponent(filterValue)}`);
+      const response = await fetch(`/unitcoordinator/units/${unitId}/bulk-staffing/sessions?type=module&value=${encodeURIComponent(filterValue)}`);
       const data = await response.json();
       return data.ok ? data.sessions : [];
     } catch (e) {
@@ -2782,7 +2722,6 @@ function initBulkStaffing() {
       return;
     }
     
-    const selectedType = document.querySelector('input[name="bulk_filter_type"]:checked')?.value;
     const respectOverrides = document.getElementById('respect_overrides')?.checked || false;
     
     try {
@@ -2793,7 +2732,7 @@ function initBulkStaffing() {
           'X-CSRFToken': window.CSRF_TOKEN
         },
         body: JSON.stringify({
-          type: selectedType,
+          type: 'module',
           value: filterValue,
           lead_staff_required: leadCount,
           support_staff_required: supportCount,

--- a/templates/unitcoordinator_dashboard.html
+++ b/templates/unitcoordinator_dashboard.html
@@ -1549,15 +1549,7 @@ Tutorial A,Tuesday,09:00,1-12,120,EZONE 1.24
                 <label class="block text-sm font-medium text-gray-700 mb-3">Choose what you want to update in bulk:</label>
                 <div class="space-y-3">
                   <label class="flex items-center">
-                    <input type="radio" name="bulk_filter_type" value="activity" class="mr-3" checked>
-                    <span>By activity</span>
-                  </label>
-                  <label class="flex items-center">
-                    <input type="radio" name="bulk_filter_type" value="session_name" class="mr-3">
-                    <span>By session name</span>
-                  </label>
-                  <label class="flex items-center">
-                    <input type="radio" name="bulk_filter_type" value="module" class="mr-3">
+                    <input type="radio" name="bulk_filter_type" value="module" class="mr-3" checked>
                     <span>By module</span>
                   </label>
                 </div>
@@ -1565,7 +1557,7 @@ Tutorial A,Tuesday,09:00,1-12,120,EZONE 1.24
 
               <!-- Filter Selection -->
               <div class="mb-6">
-                <label for="bulk_filter_select" class="block text-sm font-medium text-gray-700 mb-2">Select activity</label>
+                <label for="bulk_filter_select" class="block text-sm font-medium text-gray-700 mb-2">Select module</label>
                 <select id="bulk_filter_select" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
                   <option value="">Choose an option...</option>
                 </select>

--- a/templates/unitcoordinator_dashboard.html
+++ b/templates/unitcoordinator_dashboard.html
@@ -1591,13 +1591,6 @@ Tutorial A,Tuesday,09:00,1-12,120,EZONE 1.24
                 </label>
               </div>
 
-              <!-- Filters Toggle -->
-              <div class="mb-6">
-                <button type="button" id="show_filters" class="text-blue-600 hover:text-blue-800 text-sm flex items-center">
-                  <span>Show filters</span>
-                  <span class="ml-1">▼</span>
-                </button>
-              </div>
 
               <!-- Action Buttons -->
               <div class="flex space-x-3">


### PR DESCRIPTION
This pull request simplifies the bulk staffing feature by removing support for filtering by activity and session name, leaving only module-based filtering. The UI and backend logic have been updated to reflect this change, streamlining the user experience and reducing code complexity.

**Bulk Staffing Filtering Simplification**
* The bulk staffing filter now only supports filtering by module. Filtering by activity and session name has been removed from both the UI and the JavaScript logic. (`templates/unitcoordinator_dashboard.html` [[1]](diffhunk://#diff-8ee0afd430677463dac99cd67c65e4585148b55e00c876d56a31fb442355e27aL1552-R1560) `static/js/uc.js` [[2]](diffhunk://#diff-cb1df46134dbce94b2e52826c8c8c13e1d2d927fcedac2737c3bd385d940e80dL2612) [[3]](diffhunk://#diff-cb1df46134dbce94b2e52826c8c8c13e1d2d927fcedac2737c3bd385d940e80dL2631-L2666)
* All related code for fetching and handling activity/session name filters has been deleted, including the associated event listeners and helper functions. (`static/js/uc.js` [static/js/uc.jsL2676-L2706](diffhunk://#diff-cb1df46134dbce94b2e52826c8c8c13e1d2d927fcedac2737c3bd385d940e80dL2676-L2706))

**UI Updates**
* The filter selection label now reads "Select module" instead of "Select activity", and only the module radio button option remains (now checked by default). (`templates/unitcoordinator_dashboard.html` [templates/unitcoordinator_dashboard.htmlL1552-R1560](diffhunk://#diff-8ee0afd430677463dac99cd67c65e4585148b55e00c876d56a31fb442355e27aL1552-R1560))
* The "Show filters" toggle button has been removed from the bulk staffing UI, further simplifying the interface. (`templates/unitcoordinator_dashboard.html` [templates/unitcoordinator_dashboard.htmlL1602-L1608](diffhunk://#diff-8ee0afd430677463dac99cd67c65e4585148b55e00c876d56a31fb442355e27aL1602-L1608))

**Backend Request Changes**
* All relevant backend requests for bulk staffing now use `type=module` exclusively, and the payloads sent to the server have been updated accordingly. (`static/js/uc.js` [[1]](diffhunk://#diff-cb1df46134dbce94b2e52826c8c8c13e1d2d927fcedac2737c3bd385d940e80dL2765-R2708) [[2]](diffhunk://#diff-cb1df46134dbce94b2e52826c8c8c13e1d2d927fcedac2737c3bd385d940e80dL2796-R2735) [[3]](diffhunk://#diff-cb1df46134dbce94b2e52826c8c8c13e1d2d927fcedac2737c3bd385d940e80dL2785)