### PR TITLE
Uc

### DIFF
--- a/static/js/uc.js
+++ b/static/js/uc.js
@@ -116,6 +116,17 @@ function openEditUnitModal() {
   const semesterYear = document.querySelector('.chip--neutral').textContent.trim();
   const [semester, year] = semesterYear.split(', ');
   
+  // Extract dates from the unit card display
+  const dateText = document.querySelector('.unit-card p.text-gray-500.text-sm')?.textContent?.trim();
+  const dateMatch = dateText ? dateText.match(/(\d{1,2}\/\d{1,2}\/\d{4})\s*-\s*(\d{1,2}\/\d{1,2}\/\d{4})/) : null;
+  let startDate = null;
+  let endDate = null;
+  
+  if (dateMatch && dateMatch.length >= 3) {
+    startDate = dateMatch[1]; // MM/DD/YYYY format
+    endDate = dateMatch[2];    // MM/DD/YYYY format
+  }
+  
   // Get current unit ID from the URL or data attribute
   const currentUnitId = getUnitId();
   
@@ -133,6 +144,41 @@ function openEditUnitModal() {
     document.querySelector('input[name="semester"]').value = semester;
     document.querySelector('input[name="year"]').value = year;
     
+    // Set the dates if they were found
+    if (startDate && endDate) {
+      try {
+        // Convert MM/DD/YYYY to DD/MM/YYYY format for flatpickr
+        const startParts = startDate.split('/');
+        const endParts = endDate.split('/');
+        
+        if (startParts.length === 3 && endParts.length === 3) {
+          const startDateFormatted = `${startParts[1]}/${startParts[0]}/${startParts[2]}`;
+          const endDateFormatted = `${endParts[1]}/${endParts[0]}/${endParts[2]}`;
+          
+          // Ensure date pickers are available before setting dates
+          if (typeof startPicker !== 'undefined' && startPicker) {
+            startPicker.setDate(startDateFormatted, true);
+          }
+          if (typeof endPicker !== 'undefined' && endPicker) {
+            endPicker.setDate(endDateFormatted, true);
+          }
+          
+          // Update the hidden input values
+          const startInput = document.getElementById('start_date_input');
+          const endInput = document.getElementById('end_date_input');
+          if (startInput) startInput.value = startDateFormatted;
+          if (endInput) endInput.value = endDateFormatted;
+          
+          // Update the date summary
+          if (typeof updateDateSummary === 'function') {
+            updateDateSummary();
+          }
+        }
+      } catch (error) {
+        console.warn('Error setting unit dates in edit modal:', error);
+      }
+    }
+    
     // Update the modal title to indicate editing
     const modalTitle = document.querySelector('#create-unit-title');
     if (modalTitle) {
@@ -147,7 +193,7 @@ function openEditUnitModal() {
     
     // Skip to step 1 (Unit Information) since we're editing
     setStep(1);
-  }, 100);
+  }, 200);
 }
 
 // Also add this to handle clicking outside the modal

--- a/unitcoordinator_routes.py
+++ b/unitcoordinator_routes.py
@@ -2992,13 +2992,13 @@ def get_bulk_staffing_filters(unit_id: int):
 
         elif filter_type == "module":
 
-            # Get modules for this unit
+            # Get modules for this unit (excluding the default "General" module)
 
             modules = (
 
                 db.session.query(Module.id, Module.module_name)
 
-                .filter(Module.unit_id == unit.id)
+                .filter(Module.unit_id == unit.id, Module.module_name != "General")
 
                 .all()
 


### PR DESCRIPTION
This pull request introduces enhancements to the unit editing modal and refines module filtering in the bulk staffing filters. The most significant changes involve extracting and formatting unit date information for the modal and ensuring the "General" module is excluded from certain queries.

**Unit Edit Modal Improvements:**

* Extracts start and end dates from the unit card display and parses them for use in the edit modal (`static/js/uc.js`).
* Converts extracted dates from MM/DD/YYYY to DD/MM/YYYY format, sets them in the date pickers, updates hidden inputs, and refreshes the date summary when editing a unit (`static/js/uc.js`).
* Increases the modal initialization delay from 100ms to 200ms for improved reliability when editing units (`static/js/uc.js`).

**Bulk Staffing Filters Update:**

* Updates the module filter to exclude the default "General" module when retrieving modules for a unit (`unitcoordinator_routes.py`).